### PR TITLE
修复callNative交互，weex IOS端传递参数给js中的数据对象包含？&,导致split错误

### DIFF
--- a/src/bridge/core/common.js
+++ b/src/bridge/core/common.js
@@ -15,7 +15,9 @@ export function serializeProtocol({ action, module, method, args, callbackId }) 
 
 export function deserializeProtocol(ptcStr) {
   let ptcObj = {};
-  let arr = ptcStr && ptcStr.split(/(\?|&)/);
+  //let arr = ptcStr && ptcStr.split(/(\?|&)/);
+  //args中的json字符串某个字段可能包含了？&符号，会导致字符串分割错误；
+  let arr = ptcStr && ptcStr.substr(ptcStr.indexOf('?') + 1).split('&');
   for (let i = 0; i < arr.length; i++) {
     if (~arr[i].indexOf('=')) {
       let keyValue = arr[i].match(/([^=]*)=(.*)/);


### PR DESCRIPTION
cml://channel?action=callbackToJs&args={原生传递的数据json对象}&callbackId=http_sendRequest_callback_5

修改因为args数据对象中的字段包含？&导致split错误；